### PR TITLE
Fixed type error for recipes endpoint

### DIFF
--- a/foodini/api/v1/endpoints/recipe.py
+++ b/foodini/api/v1/endpoints/recipe.py
@@ -19,7 +19,7 @@ def get_recipes(
     db: Session = Depends(deps.database),
     response: Response
 ) -> List[models.Recipe]:
-    response.headers["Total-Count"] = crud.recipe.count(db)
+    response.headers["Total-Count"] = str(crud.recipe.count(db))
     return crud.recipe.read_multi(db, skip=skip, limit=limit)
 
 


### PR DESCRIPTION
This fixes a issue with the /recipes endpoint encoutering an AttributeError when encoding a count.

```
 Traceback (most recent call last):
   File "/usr/local/lib/python3.10/site-packages/anyio/streams/memory.py", line 94, in receive
     return self.receive_nowait()
   File "/usr/local/lib/python3.10/site-packages/anyio/streams/memory.py", line 89, in receive_nowait
     raise WouldBlock
 anyio.WouldBlock

 During handling of the above exception, another exception occurred:

 Traceback (most recent call last):
   File "/usr/local/lib/python3.10/site-packages/starlette/middleware/base.py", line 43, in call_next
     message = await recv_stream.receive()
   File "/usr/local/lib/python3.10/site-packages/anyio/streams/memory.py", line 114, in receive
     raise EndOfStream
 anyio.EndOfStream

 During handling of the above exception, another exception occurred:

 Traceback (most recent call last):
   File "/usr/local/lib/python3.10/site-packages/uvicorn/protocols/http/httptools_impl.py", line 372, in run_asgi
     result = await app(self.scope, self.receive, self.send)
   File "/usr/local/lib/python3.10/site-packages/uvicorn/middleware/proxy_headers.py", line 75, in __call__
     return await self.app(scope, receive, send)
   File "/usr/local/lib/python3.10/site-packages/fastapi/applications.py", line 269, in __call__
     await super().__call__(scope, receive, send)
   File "/usr/local/lib/python3.10/site-packages/starlette/applications.py", line 124, in __call__
     await self.middleware_stack(scope, receive, send)
   File "/usr/local/lib/python3.10/site-packages/starlette/middleware/errors.py", line 184, in __call__
     raise exc
   File "/usr/local/lib/python3.10/site-packages/starlette/middleware/errors.py", line 162, in __call__
     await self.app(scope, receive, _send)
   File "/usr/local/lib/python3.10/site-packages/starlette/middleware/base.py", line 68, in __call__
     response = await self.dispatch_func(request, call_next)
   File "/app/app.py", line 57, in add_process_time_header
     response = await call_next(request)
   File "/usr/local/lib/python3.10/site-packages/starlette/middleware/base.py", line 46, in call_next
     raise app_exc
   File "/usr/local/lib/python3.10/site-packages/starlette/middleware/base.py", line 36, in coro
     await self.app(scope, request.receive, send_stream.send)
   File "/usr/local/lib/python3.10/site-packages/starlette/middleware/cors.py", line 84, in __call__
     await self.app(scope, receive, send)
   File "/usr/local/lib/python3.10/site-packages/starlette/exceptions.py", line 93, in __call__
     raise exc
   File "/usr/local/lib/python3.10/site-packages/starlette/exceptions.py", line 82, in __call__
     await self.app(scope, receive, sender)
   File "/usr/local/lib/python3.10/site-packages/fastapi/middleware/asyncexitstack.py", line 21, in __call__
     raise e
   File "/usr/local/lib/python3.10/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
     await self.app(scope, receive, send)
   File "/usr/local/lib/python3.10/site-packages/starlette/routing.py", line 670, in __call__
     await route.handle(scope, receive, send)
   File "/usr/local/lib/python3.10/site-packages/starlette/routing.py", line 266, in handle
     await self.app(scope, receive, send)
   File "/usr/local/lib/python3.10/site-packages/starlette/routing.py", line 65, in app
     response = await func(request)
   File "/usr/local/lib/python3.10/site-packages/fastapi/routing.py", line 227, in app
     raw_response = await run_endpoint_function(
   File "/usr/local/lib/python3.10/site-packages/fastapi/routing.py", line 162, in run_endpoint_function
     return await run_in_threadpool(dependant.call, **values)
   File "/usr/local/lib/python3.10/site-packages/starlette/concurrency.py", line 41, in run_in_threadpool
     return await anyio.to_thread.run_sync(func, *args)
   File "/usr/local/lib/python3.10/site-packages/anyio/to_thread.py", line 31, in run_sync
     return await get_asynclib().run_sync_in_worker_thread(
   File "/usr/local/lib/python3.10/site-packages/anyio/_backends/_asyncio.py", line 937, in run_sync_in_worker_thread
     return await future
   File "/usr/local/lib/python3.10/site-packages/anyio/_backends/_asyncio.py", line 867, in run
     result = context.run(func, *args)
   File "/app/api/v1/endpoints/recipe.py", line 44, in get_recipes
     response.headers["Total-Count"] = crud.recipe.count(db)
   File "/usr/local/lib/python3.10/site-packages/starlette/datastructures.py", line 591, in __setitem__
     set_value = value.encode("latin-1")
 AttributeError: 'int' object has no attribute 'encode'
 ```